### PR TITLE
build: fix errors in the build process

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -1,3 +1,4 @@
+import { createRequire } from 'module'; const require = createRequire(import.meta.url);
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "src/main.ts",
   "scripts": {
-    "build": "esbuild ./src/main.ts --bundle --outdir=dist --platform=node --target=node24.0.0 --packages=bundle --format=esm --external:debug",
+    "build": "esbuild ./src/main.ts --bundle --outdir=dist --platform=node --target=node24.0.0 --packages=bundle --format=esm --external:debug --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\"",
     "format": "prettier --write '**/*.ts'",
     "format-check": "prettier --check '**/*.ts'",
     "test": "vitest run --coverage",


### PR DESCRIPTION
```
throw Error('Dynamic require of "' + x + '" is not supported');
          ^

  Error: Dynamic require of "net" is not supported
      at file:///home/runner/work/_actions/redhat-plumbers-in-action/auto-merge/v3/dist/main.js:11:9
      at node_modules/tunnel/lib/tunnel.js (file:///home/runner/work/_actions/redhat-plumbers-in-action/auto-merge/v3/dist/main.js:41:15)
      at __require2 (file:///home/runner/work/_actions/redhat-plumbers-in-action/auto-merge/v3/dist/main.js:14:50)
      at node_modules/tunnel/index.js (file:///home/runner/work/_actions/redhat-plumbers-in-action/auto-merge/v3/dist/main.js:270:22)
      at __require2 (file:///home/runner/work/_actions/redhat-plumbers-in-action/auto-merge/v3/dist/main.js:14:50)
      at file:///home/runner/work/_actions/redhat-plumbers-in-action/auto-merge/v3/dist/main.js:39167:22
      at ModuleJob.run (node:internal/modules/esm/module_job:430:25)
      at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:661:26)
      at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
```